### PR TITLE
bootstrap.sh: Add sleep to allow message output to get displayed

### DIFF
--- a/builder/board/nerves_initramfs_edge/bootstrap.sh
+++ b/builder/board/nerves_initramfs_edge/bootstrap.sh
@@ -2,10 +2,11 @@
 set -e
 
 err_exit() {
-  echo "Failed to flash firmware via USB"
-  echo
-  echo "You can try flashing via tftp with:"
-  echo "fwup-tftp"
+  echo "Failed to flash firmware via USB" 1>&2
+  echo 1>&2
+  echo "You can try flashing via tftp with:" 1>&2
+  echo "fwup-tftp" 1>&2
+  sleep 1
 }
 
 trap 'err_exit' ERR


### PR DESCRIPTION
Without the sleep, the err_exit() output doesn't get shown on the serial console when it is executed by nerves_initramfs pid 1 process