### PR TITLE
VERSION: v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.7.1
+
+* fwup-tftp: Add sleep to allow err_exit output to get displayed
+
 ## v0.7.0
 
 * fwup 1.10.1

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.0
+VERSION=0.7.1
 
 BISON ?= bison
 FLEX ?= flex


### PR DESCRIPTION
## v0.7.1

* fwup-tftp: Add sleep to allow err_exit output to get displayed